### PR TITLE
README: substitute travis-ci.org for travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![build](https://travis-ci.org/tolstoyevsky/hubot-viva-las-vegas.svg?branch=master)](https://travis-ci.org/tolstoyevsky/hubot-viva-las-vegas)
+[![build](https://travis-ci.com/tolstoyevsky/hubot-viva-las-vegas.svg?branch=master)](https://travis-ci.org/tolstoyevsky/hubot-viva-las-vegas)
 
 # hubot-viva-las-vegas
 


### PR DESCRIPTION
https://blog.travis-ci.com/2018-05-02-open-source-projects-on-travis-ci-com-with-github-apps